### PR TITLE
fix OreBag

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -319,7 +319,7 @@
     radius: 1.8
     energy: 2
     color: red
-    mask: /Textures/Effects/LightMasks/double_cone.png 
+    mask: /Textures/Effects/LightMasks/double_cone.png
   - type: RotatingLight
     speed: 360
   - type: ContainerContainer
@@ -435,7 +435,7 @@
   - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
-  - type: SupermatterImmune 
+  - type: SupermatterImmune
   # ADT-Tweak-end
 
 #Chief Medical Officer's Hardsuit
@@ -935,7 +935,7 @@
   - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
-  - type: SupermatterImmune 
+  - type: SupermatterImmune
   # ADT-Tweak-end
 
 #ERT Medic Hardsuit
@@ -1030,7 +1030,7 @@
   - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
-  - type: SupermatterImmune 
+  - type: SupermatterImmune
   # ADT-Tweak-end
 
 #CBURN Hardsuit

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -5,7 +5,7 @@
   description: A robust bag for salvage specialists and miners alike to carry large amounts of ore. Magnetises any nearby ores when attached to a belt.
   components:
   - type: MagnetPickup
-    slotFlags: POCKET # ADT tweak belt -> POCKET
+    slotFlags: [BELT, POCKET] # ADT tweak belt -> POCKET
   - type: Sprite
     sprite: Objects/Specific/Mining/ore_bag.rsi
     state: icon


### PR DESCRIPTION
## Описание PR

Теперь руда собирается как в кармане, так и на поясе.

## Почему / Баланс
Шахтеры будут рады.
Ссылка на заказ, предложение или баг-репорт
(https://discord.com/channels/1354120935225167883/1357709747255509256/1359469999512748233)

## Техническая информация


## Медиа
![image](https://github.com/user-attachments/assets/0de8597a-f761-449a-94bd-45167f8439c5)

## Чейнджлог
<!--
:cl: (MiFix2281337)
- add: -
- remove: -
- tweak: был изменен slotflags. Изначально там стояло значения POCKET, то есть руда работала только в том случае, если сумка находится в кармане. Теперь значение [BELT, POCKET] и сумка будет собирать руду как в кармане, так и на поясе.
- fix: -
-->
