### PR TITLE
[FIX] Показ ERP статуса теперь не зависит от наличия описания

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -25,7 +25,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
-using Content.Shared.SD;
 
 namespace Content.Server.Station.Systems;
 

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -25,6 +25,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
+using Content.Shared.SD;
 
 namespace Content.Server.Station.Systems;
 
@@ -184,14 +185,16 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
 
             _humanoidSystem.LoadProfile(entity.Value, profile);
             _metaSystem.SetEntityName(entity.Value, profile.Name);
-            if (profile.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
+            // SD-ERPStatus-Start
+            if (_configurationManager.GetCVar(CCVars.FlavorText))
             {
-                // SD-ERPStatus-Start
-                var _DetailExamineComp = EntityManager.AddComponent<DetailExaminableComponent>(entity.Value);
-                _DetailExamineComp.Content = profile.FlavorText;
-                _DetailExamineComp.ERPStatus = profile.ERPStatus;
-                // SD-ERPStatus-End
+                var detailExamineComp = EntityManager.EnsureComponent<DetailExaminableComponent>(entity.Value);
+                detailExamineComp.Content = profile.FlavorText ?? "";
+
+                // Сохраняем ERPStatus независимо от наличия FlavorText
+                detailExamineComp.ERPStatus = profile.ERPStatus;
             }
+            // SD-ERPStatus-End
         }
 
         DoJobSpecials(job, entity.Value);


### PR DESCRIPTION
## Описание PR
Мелкий фикс

## Почему / Баланс
- [Баг-репорт](https://discord.com/channels/1354120935225167883/1357709747255509256/1360530930552537271)

## Чейнджлог
:cl: Шрёдька
- fix: Показ ERP статуса теперь не зависит от наличия описания.
