### PR TITLE
[BUG] re-add shield's unability to shoot

### DIFF
--- a/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
+++ b/Resources/Prototypes/ADT/Roles/Jobs/Command/blueshieldofficer.yml
@@ -47,6 +47,11 @@
     implants: [ MindShieldImplant ]
   - !type:AddComponentSpecial
       components:
+        - type: CantShoot
+          popup: combo-cantshoot
+          whitelist:
+            tags:
+            - ADTBsoWeapon
         - type: Puller
           grabStats:
             None:


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->

## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
Во время ПРа на обновление CQC синего щита я случайно удалил компонент CantShoot, не позволявший ОСЩ стрелять ни из чего, кроме оружия с соответствующим тэгом. В качестве баланса вселенной и игры - я возвращаю эту фичу, ибо щиты начнут лутать оружие из оружейки раундстартом. 

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->

## Чейнджлог
no cl no fun 
