### PR TITLE
Разрешить резоми занимать роли СБ

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -10,7 +10,7 @@
     - !type:SpeciesRequirement
       inverted: true
       species:
-      - Resomi
+      #- Resomi SD-edit
       - Vox
     # ADT RESTRICT End
   startingGear: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -11,7 +11,7 @@
     - !type:SpeciesRequirement
       inverted: true
       species:
-      - Resomi
+      # - Resomi SD-edit
       - Vox
   # ADT RESTRICT End
   startingGear: SecurityOfficerGear


### PR DESCRIPTION
## Описание PR
Теперь резоми могут занимать роли в СБ (только кадетов и офицеров, варденов и хосов еще рано)

## Почему / Баланс
Меня попросили

## Техническая информация
Ээээ я коммент вставил

## Чейнджлог
<!--
:cl: (Kel593)
- tweak: Теперь резоми могут занимать роли офицеров и кадетов СБ
-->
