### PR TITLE
ТГ фонарик у ПДА

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -64,9 +64,10 @@
   - type: UnpoweredFlashlight
   - type: PointLight
     enabled: false
-    radius: 1.5
-    softness: 5
+    mask: /Textures/Effects/LightMasks/cone.png
     autoRot: true
+    radius: 2
+    netsync: false
   - type: Ringer
   - type: DeviceNetwork
     deviceNetId: Wireless


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
В этом пуллреквесте я сделал ТГ подобные фонарики у ПДА
## Почему / Баланс
<!-- Почему оно было изменено и как изменение повлияет на игру и её баланс. -->
У ПДА всё время был бесполезный фонарик. Который ничего не освещал. Теперь у ПДА есть слабый фонарик что светит вперёд. Он не такой сильный дабы освещать все помещение. Но примерно на один тайл вперед сможет осветить.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа

![PR](https://github.com/user-attachments/assets/766ea5bb-288c-40c2-83cf-02d5e2a37a4b)
