### PR TITLE
[TWEAK] Приведение характеристик охранного МОДа к характеристикам с ВП

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/Back/mods.yml
@@ -272,6 +272,16 @@
         whitelist:
           components:
           - ModSuitMod
+      modsuit-mod3:
+        swap: false
+        whitelist:
+          components:
+          - ModSuitMod
+      modsuit-mod4:
+        swap: false
+        whitelist:
+          components:
+          - ModSuitMod
   - type: ContainerContainer
     containers:
       modsuit-part: !type:Container
@@ -287,6 +297,14 @@
         occludes: True
         ent: null
       modsuit-mod2: !type:ContainerSlot
+        showEnts: False
+        occludes: True
+        ent: null
+      modsuit-mod3: !type:ContainerSlot
+        showEnts: False
+        occludes: True
+        ent: null
+      modsuit-mod4: !type:ContainerSlot
         showEnts: False
         occludes: True
         ent: null

--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -183,14 +183,18 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Heat: 0.6
-        Piercing: 0.6
+        Blunt: 0.7
+        Slash: 0.7
+        Heat: 0.8
+        Piercing: 0.55
         Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  - type: ExplosionResistance
+    damageCoefficient: 0.6
+  - type: FireProtection
+    reduction: 0.75
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase


### PR DESCRIPTION
## Описание PR
Защитные характеристики охранного мода приведены к таковым с ВП - улучшена защита от пуль, добавлена защита от взрыва и от нагрева носителя при нахождении внутри пожара

Уменьшена сильно защита от лазерного оружия и слабо - уменьшена защита от ударов и порезов

Плюс увеличено число слотов

## Почему / Баланс
https://discord.com/channels/1354120935225167883/1365980734044635167/1366428839781335092

## Чейнджлог
:cl: Петр
- tweak: Увеличено число слотов охранного МОДа с 3 до 5
- tweak: Параметры защиты охранного МОДа частично улучшены (защита от взрывов и пуль), частично ухудшены (защита от лазеров и от бланта)