### PR TITLE
Понижение доступа у сервисного работника

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -9,10 +9,14 @@
   access:
   - Service
   - Maintenance
-  - Bar
-  - Kitchen
+  # SD tweak start, даем понять сервису его правильное место
+  # - Bar
+  # - Kitchen
   extendedAccess:
   - Hydroponics
+  - Bar
+  - Kitchen
+  # SD tweak end
 
 - type: startingGear
   id: ServiceWorkerGear


### PR DESCRIPTION
## Описание PR
<!-- Что вы изменили в этом пулл-реквесте? -->
Сервисный работник утратил доступ в бар и на кухню.
Доступы бара и кухни выдаются сервису автоматически, если на станции отсутствуют бармен и/или повар

## Почему / Баланс
В текущий момент сервисный работник имеет доступы от всего отдела сервиса, что делает эту роль очень хорошей для манча снаряжения и набегаторов.

![image](https://github.com/user-attachments/assets/ac4df0a1-eb6f-4dd3-9bea-950e46eb358f)
Согласно википедии ADT сервисный работник (огузок) имеет право работать на месте бармена/повара только при их отсутствии или разрешении от них самих или главы персонала, ясен хуй что всем кто заходит на эту роль немного насрать на то что у них там в СРПшках написано.

С мерджем ПРа, если сервис хочет работать у бармена или повара, он либо попросит нужное снаряжение и будет работать непосредственно вместе с барменом/поваром без манча всевозможных бронежилетов, ножей и очков, либо попросит у ГП дополнительные доступы для работы.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->

## Медиа
<!--Вставьте медиа, демонстрирующее изменения, если это требуется-->
![image](https://github.com/user-attachments/assets/ae3ee9e7-66e7-4008-a907-cd50a0b553b1)

## Чейнджлог
:cl: Aserovich
- tweak: Изменены доступы сервисного работника
