### PR TITLE
more expensive harvaster

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/ADT/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -265,12 +265,13 @@
   - type: MachineBoard
     prototype: ADTBluespaceHarvester
     stackRequirements:
-      Glass: 15
-      Steel: 15
-      CableHV: 5
-      Manipulator: 5
-      Capacitor: 5
-      MatterBin: 15
+      Glass: 200
+      Steel: 200
+      Diamond: 20
+      CableHV: 50
+      Manipulator: 20
+      Capacitor: 20
+      MatterBin: 40
     tagRequirements:
       GlassBeaker:
         amount: 5

--- a/Resources/Prototypes/ADT/Research/experimental.yml
+++ b/Resources/Prototypes/ADT/Research/experimental.yml
@@ -27,7 +27,7 @@
     state: ansible_crystal
   discipline: Experimental
   tier: 2
-  cost: 40000
+  cost: 685183
   recipeUnlocks:
   - ADTMachineBluespaceHarvesterCircuitboard
   position: 4,-3


### PR DESCRIPTION
## Описание PR
Более дорогой харвастер.

## Почему / Баланс
Баланс харвастера. Появление в игре слишком рано, а так же из-за большого их количества.

## Техническая информация
Стоимость харвастера выросла до 685183.

## Медиа
![image](https://github.com/user-attachments/assets/4a1361f7-6960-4b76-9551-dcbdb769755c)

## Чейнджлог

