### PR TITLE
[Maps] added SD_Flicker

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -60,6 +60,10 @@ namespace Content.IntegrationTests.Tests
 
         private static readonly string[] GameMaps =
         {
+            // SD-Start
+            "SD_Flicker",
+            // SD-End
+
             // Corvax-Start
             // "CorvaxAvrite", // ADT-Comment
             // "CorvaxDelta",

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -34,6 +34,7 @@
 # SD maps Актуальные
 
   - SD_Sievert
+  - SD_Flicker
 
 # ADT Maps Выведенные на переработку
   # - ADT_Avrit требуется декорваксизация

--- a/Resources/Prototypes/SD/Maps/sd_flicker.yml
+++ b/Resources/Prototypes/SD/Maps/sd_flicker.yml
@@ -1,0 +1,77 @@
+- type: gameMap
+  id: SD_Flicker
+  mapName: 'Flicker Station'
+  mapPath: /Maps/SDMaps/SDStations/sd_flicker.yml
+  minPlayers: 5
+  maxPlayers: 80
+  stations:
+    ADT_kilo:
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationNameSetup
+          mapNameTemplate: '{0}FLK {1}'
+          nameGenerator:
+            !type:NanotrasenNameGenerator
+            prefixCreator: '-'
+        - type: StationEmergencyShuttle
+          emergencyShuttlePath: /Maps/Shuttles/emergency_lox.yml
+        - type: StationJobs
+          availableJobs:
+            # command
+            Captain: [ 1, 1 ]
+            ADTBlueShieldOfficer: [ 1, 1 ]
+            #service
+            HeadOfPersonnel: [ 1, 1 ]
+            Bartender: [ 2, 2 ]
+            Botanist: [ 3, 3 ]
+            Chef: [ 2, 2 ]
+            Janitor: [ 3, 3 ]
+            Chaplain: [ 1, 1 ]
+            Librarian: [ 1, 1 ]
+            ServiceWorker: [ 2, 2 ]
+            #engineering
+            ChiefEngineer: [ 1, 1 ]
+            AtmosphericTechnician: [ 3, 3 ]
+            StationEngineer: [ 4, 4 ]
+            TechnicalAssistant: [ 4, 4 ]
+            ADTSeniorEngineer: [ 1, 1 ]
+            #medical
+            ChiefMedicalOfficer: [ 1, 1 ]
+            Chemist: [ 2, 2 ]
+            MedicalDoctor: [ 3, 3 ]
+            Paramedic: [ 1, 1 ]
+            MedicalIntern: [ 4, 4 ]
+            ADTPathologist: [ 1, 1 ]
+            ADTSeniorPhysician: [ 1, 1 ]
+            #science
+            ResearchDirector: [ 1, 1 ]
+            Scientist: [ 5, 5 ]
+            ResearchAssistant: [ 4, 4 ]
+            ADTRoboticist: [ 1, 2 ]
+            ADTSeniorResearcher: [ 1, 1 ]
+            #security
+            HeadOfSecurity: [ 1, 1 ]
+            Warden: [ 1, 1 ]
+            SecurityOfficer: [ 4, 4 ]
+            Detective: [ 1, 1 ]
+            SecurityCadet: [ 4, 4 ]
+            Brigmedic: [ 1, 1 ]
+            ADTSeniorOfficer: [ 1, 1 ]
+            ADTGuardOfficer: [ 1, 1 ]
+            #supply
+            Quartermaster: [ 1, 1 ]
+            SalvageSpecialist: [ 3, 3 ]
+            CargoTechnician: [ 3, 3 ]
+            #civilian
+            Passenger: [ -1, -1 ]
+            Clown: [ 1, 1 ]
+            Mime: [ 1, 1 ]
+            Musician: [ 1, 1 ]
+            Reporter: [ 2, 2 ]
+            # juridical
+            Lawyer: [ 1, 1 ]
+            IAA: [ 1, 1 ]
+            # Magistrat: [ 1, 1 ]
+            #silicon
+            StationAi: [ 1, 1 ]
+            Borg: [ 2, 2 ]


### PR DESCRIPTION
## Описание PR
Добавлена новая (старая) карта SD_Flicker (в переводе: *мерцание, вспышка*) на основе ADT_kilo. Название отсылает к огромному количеству выключателей света почти в каждом помещении на этой станции.

Общие изменения:
- перестроены комнаты в дормах;
- в голодек добавлен пляж;
- чуть изменён суд с добавлением логики;
- ко всем главам добавлены кровать, комод и одеяло;
- прошёлся по [маппинг-чеклисту Corvax NEXT](https://docs.google.com/spreadsheets/d/1AQ96qbt5WDvRfi-v4uf7iw9xSRHK88GoMWKKAKNPYf8/edit?gid=0#gid=0) и исправил недочёты;
- по станции раскиданы упакованные принтеры с мультитулами;
- в бриг добавлена комната уборщика;
- на станцию добавлен пластик по отделам;
- заново расставлены все станционные маяки на станции и поставлены цели взрыва для ниндзя;
- полностью перестроен пермабриг, чтобы сделать его меньше и красивей;
- перестроены доки СБ, чтобы к ним мог стыковаться шаттл;
- полностью перестроен атмосферный отсек в сторону уменьшения и повышения функциональности;
- добавлен ТЭГ;
- включен гейт;
- добавлена стойка СБ;
- добавлены заброшенные стыковочные порты.

Полный список изменений можно посмотреть в описании коммитов.

## Почему / Баланс
Очень понравилась карта, но не понравились критические недостатки, поэтому исправил её для Space Dreams.

## Техническая информация
Принтеры почему-то не сохраняются в файл карты: пришлось костылить с упакованными.

## Медиа
Пермабриг:
<img width="1524" height="575" alt="пермабриг" src="https://github.com/user-attachments/assets/fd3cde25-0985-4698-a662-5fb67d5ace80" />

Доки СБ + атмос:
<img width="3050" height="1226" alt="изображение" src="https://github.com/user-attachments/assets/b65da556-7a6a-4cdb-bea1-5b6bda67e3eb" />

Рендер:
<img width="5472" height="4992" alt="SD_Flicker-0" src="https://github.com/user-attachments/assets/f49fd310-4cfa-4008-a205-58d2b8b8bd73" />