### PR TITLE
Уменьшение резистов к огню у всех МОДов

### DIFF
--- a/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
+++ b/Resources/Prototypes/ADT/Entities/Clothing/OuterClothing/modsuits.yml
@@ -37,7 +37,7 @@
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
   - type: FireProtection
-    reduction: 0.25
+    reduction: 0.25 # SD tweak 0.5 -> 0.25
   - type: CoveredSlot
     slots: [innerclothing, underwearb, underweart, socks]
 
@@ -76,7 +76,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.7
   - type: FireProtection
-    reduction: 1
+    reduction: 0.8 # SD tweak 1 -> 0.8
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -103,8 +103,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1
-  - type: FireProtection
-    reduction: 0.5
+  # SD tweak start
+  #- type: FireProtection
+  #  reduction: 0.5
+  # SD tweak end
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -135,8 +137,10 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.85
-  - type: FireProtection
-    reduction: 1
+  # SD tweak start
+  #- type: FireProtection
+  #  reduction: 1
+  # SD tweak end
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -165,8 +169,10 @@
     sprintModifier: 0.85
   - type: ExplosionResistance
     damageCoefficient: 0.8
-  - type: FireProtection
-    reduction: 0.6
+  # SD tweak start
+  #- type: FireProtection
+  #  reduction: 0.6
+  # SD tweak end
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -196,7 +202,7 @@
     walkModifier: 0.9
     sprintModifier: 0.85
   - type: FireProtection
-    reduction: 1
+    reduction: 0.8 # SD tweak 1 -> 0.8
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -228,8 +234,10 @@
     sprintModifier: 0.9
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: FireProtection
-    reduction: 0.75
+  # SD tweak start
+  #- type: FireProtection
+  #  reduction: 0.75
+  # SD tweak end
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -261,7 +269,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: FireProtection
-    reduction: 0.9
+    reduction: 0.6 # SD tweak 0.9 -> 0.6
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -294,7 +302,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -327,7 +335,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5
 
 - type: entity
   parent: ADTClothingOuterModsuitBodyBase
@@ -359,7 +367,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.5
   - type: FireProtection
-    reduction: 1
+    reduction: 0.8 # SD tweak 1 -> 0.8
   - type: ClothingGrantComponent
     component:
     - type: SupermatterImmune
@@ -397,7 +405,7 @@
     walkModifier: 1
     sprintModifier: 1
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5
 
 - type: entity
   parent: ADTClothingOuterModsuitBodySyndicate
@@ -434,7 +442,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5
 
 - type: entity
   parent: ADTClothingOuterModsuitBodySyndicate
@@ -471,7 +479,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5
 
 - type: entity
   parent: ADTClothingOuterModsuitBodySyndicate
@@ -507,4 +515,4 @@
   - type: ExplosionResistance
     damageCoefficient: 0.6
   - type: FireProtection
-    reduction: 1
+    reduction: 0.5 # SD tweak 1 -> 0.5


### PR DESCRIPTION
## Описание PR
Уменьшаем резисты к огню(не путать с защитой от heat урона) у большинство МОДов.

## Почему / Баланс
Почему у большинства МОДов в игре 100% защита от огня? У СБ МОДов вообще 75% процентов защиты от огня. Выходит что у всего СБ отдела огромная защита от Еретика с путем пепла, да и вообще к любому поджогу и плазмафлуду. Поджог и так контрится обливаем себя водой. Такие бешеные резисты не только делают необычные ловушки и средства бесполезными, но и убивают всю уникальность атмос-скафандров и пожарных атмос-костюмов.

## Техническая информация
<!-- Если речь идет об изменении кода, кратко изложите на высоком уровне принцип работы нового кода. Перечислите все критические изменения, включая изменения пространства имён, публичных классов/методов/полей- -->
- [X] Изменения были протестированы на локальном сервере, и всё работает отлично.
- [X] PR закончен и требует просмотра изменений.

## Медиа
(лишь некоторые изменения резистов)
<img width="423" height="339" alt="изображение" src="https://github.com/user-attachments/assets/e676b565-9cc4-4cff-92d0-72bc04de4df4" />
<img width="408" height="326" alt="изображение" src="https://github.com/user-attachments/assets/e9ff6628-a869-4fa3-9509-33a5866994b2" />
<img width="404" height="325" alt="изображение" src="https://github.com/user-attachments/assets/bede9bc0-6212-44ca-a78f-9608af0ffde9" />

## Чейнджлог
:cl: Gorox
- tweak: Изменены резисты к огню у всех МОДов.
